### PR TITLE
Enhancement: Validate composer.json and composer.lock on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ cache:
     - vendor
     - bin
 
-before_script: composer install --no-dev
+before_script:
+  - composer validate
+  - composer install --no-dev
 
 script:
   - bin/phpunit


### PR DESCRIPTION
This PR

* [x] validates `composer.json` and `composer.lock` on Travis

💁‍♂️ The advantage of doing this is that - since `composer.lock` is checked in - we can verify if it is up to date with `composer.json`.

For reference, see https://getcomposer.org/doc/03-cli.md#validate.