### PR TITLE
Fix: Cache composer cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ php:
 
 cache:
   directories:
-    - vendor
-    - bin
+    - $HOME/.composer/cache
 
 before_script: composer install --no-dev
 


### PR DESCRIPTION
This PR

* [x] caches `composer`s cache instead of `bin` and `vendor`

💁‍♂️ For reference, see 

* https://docs.travis-ci.com/user/caching/#Arbitrary-directories
* https://getcomposer.org/doc/06-config.md#cache-dir
